### PR TITLE
[FEAT] 트랙 피드 조회 API 페이지네이션

### DIFF
--- a/src/main/java/com/cabin/plat/domain/track/controller/TrackController.java
+++ b/src/main/java/com/cabin/plat/domain/track/controller/TrackController.java
@@ -4,12 +4,17 @@ import com.cabin.plat.config.AuthMember;
 import com.cabin.plat.domain.member.entity.Member;
 import com.cabin.plat.domain.track.dto.TrackRequest;
 import com.cabin.plat.domain.track.dto.TrackResponse;
+import com.cabin.plat.domain.track.dto.TrackResponse.TrackDetail;
 import com.cabin.plat.domain.track.service.TrackService;
 import com.cabin.plat.global.common.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/tracks")
@@ -61,10 +66,13 @@ public class TrackController {
         return BaseResponse.onSuccess(trackService.addTrack(member, trackUpload));
     }
 
-    @Operation(summary = "트랙 피드 조회", description = "트랙의 피드를 모두 조회한다.")
+    @Operation(summary = "트랙 피드 조회", description = "트랙의 피드를 조회한다. 페이지네이션을 지원합니다. page 파라미터에 페이지 번호를 입력해주세요.")
     @GetMapping("/feeds")
-    public BaseResponse<TrackResponse.TrackDetailList> getTrackFeeds(@AuthMember Member member) {
-        return BaseResponse.onSuccess(trackService.getTrackFeeds(member));
+    public BaseResponse<TrackResponse.TrackDetailList> getTrackFeeds(
+            @AuthMember Member member,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return BaseResponse.onSuccess(trackService.getTrackFeeds(member, page, size));
     }
 
     @Operation(summary = "트랙 신고", description = "트랙을 신고한다.")

--- a/src/main/java/com/cabin/plat/domain/track/repository/TrackRepository.java
+++ b/src/main/java/com/cabin/plat/domain/track/repository/TrackRepository.java
@@ -3,6 +3,8 @@ package com.cabin.plat.domain.track.repository;
 import com.cabin.plat.domain.track.entity.Track;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -19,4 +21,5 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
             @Param("maxLatitude") double maxLatitude,
             @Param("minLongitude") double minLongitude,
             @Param("maxLongitude") double maxLongitude);
+    Page<Track> findAll(Pageable pageable);
 }

--- a/src/main/java/com/cabin/plat/domain/track/service/TrackService.java
+++ b/src/main/java/com/cabin/plat/domain/track/service/TrackService.java
@@ -3,8 +3,6 @@ package com.cabin.plat.domain.track.service;
 import com.cabin.plat.domain.member.entity.Member;
 import com.cabin.plat.domain.track.dto.TrackRequest;
 import com.cabin.plat.domain.track.dto.TrackResponse;
-import com.cabin.plat.domain.track.dto.TrackResponse.TrackMapList;
-import com.cabin.plat.global.common.BaseResponse;
 
 public interface TrackService {
     TrackResponse.TrackMapList getTracksByLocation(
@@ -21,7 +19,7 @@ public interface TrackService {
 
     TrackResponse.TrackId addTrack(Member member, TrackRequest.TrackUpload trackUpload);
 
-    TrackResponse.TrackDetailList getTrackFeeds(Member member);
+    TrackResponse.TrackDetailList getTrackFeeds(Member member, int page, int size);
 
     TrackResponse.ReportId reportTrack(Member member, Long trackId);
 }

--- a/src/main/java/com/cabin/plat/domain/track/service/TrackServiceImpl.java
+++ b/src/main/java/com/cabin/plat/domain/track/service/TrackServiceImpl.java
@@ -10,12 +10,14 @@ import com.cabin.plat.domain.track.repository.*;
 import com.cabin.plat.global.exception.RestApiException;
 import com.cabin.plat.global.exception.errorCode.TrackErrorCode;
 import com.cabin.plat.global.util.geocoding.AddressInfo;
-import com.cabin.plat.global.util.geocoding.ApiKeyProperties;
 import com.cabin.plat.global.util.geocoding.ReverseGeoCoding;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -109,8 +111,12 @@ public class TrackServiceImpl implements TrackService {
     }
 
     @Override
-    public TrackResponse.TrackDetailList getTrackFeeds(Member member) {
-        List<Track> tracks = trackRepository.findAll(); // TODO: 페이지네이션 또는 친구 트랙만 불러오기
+    public TrackResponse.TrackDetailList getTrackFeeds(Member member, int page, int size) {
+        List<Sort.Order> sorts = new ArrayList<>();
+        sorts.add(Sort.Order.desc("createdAt"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(sorts));
+
+        List<Track> tracks = trackRepository.findAll(pageable).getContent();
 
         List<TrackResponse.TrackDetail> trackDetails = tracks.stream()
                 .map(track -> getTrackDetail(member, track))

--- a/src/test/java/com/cabin/plat/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/cabin/plat/domain/track/service/TrackServiceTest.java
@@ -293,10 +293,26 @@ class TrackServiceTest {
         Member member = members.get(0);
 
         // when
-        List<TrackDetail> trackDetails = trackService.getTrackFeeds(member).getTrackDetails();
+        List<TrackDetail> trackDetails = trackService.getTrackFeeds(member, 0, 20).getTrackDetails();
 
         // then
         assertThat(trackDetails).hasSize(6);
+    }
+
+    @Test
+    void 트랙_피드_페이지네이션() {
+        // given
+        Member member = members.get(0);
+
+        // when
+        List<TrackDetail> firstPageTracks = trackService.getTrackFeeds(member, 0, 4).getTrackDetails();
+        List<TrackDetail> secondPageTracks = trackService.getTrackFeeds(member, 1, 4).getTrackDetails();
+        List<TrackDetail> thirdPageTracks = trackService.getTrackFeeds(member, 2, 4).getTrackDetails();
+
+        // then
+        assertThat(firstPageTracks).hasSize(4);
+        assertThat(secondPageTracks).hasSize(2);
+        assertThat(thirdPageTracks).hasSize(0);
     }
 
     @Test


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#47/feedsPaging -> develop

### 변경 사항
트랙 피드 조회 API 를 페이지네이션 가능하도록 변경했습니다.

### 테스트 결과
<img width="876" alt="image" src="https://github.com/user-attachments/assets/91435540-d207-48f8-bf98-60d443957506">

<img width="418" alt="image" src="https://github.com/user-attachments/assets/3c0da1a3-2430-41c9-a5a3-3cf94d162f35">

