### PR TITLE
refactor: #54 이미지 업로드 API 엔드포인트 변경

### DIFF
--- a/src/main/java/com/cabin/plat/config/SecurityConfig.java
+++ b/src/main/java/com/cabin/plat/config/SecurityConfig.java
@@ -57,7 +57,8 @@ public class SecurityConfig {
                         .requestMatchers("/test").authenticated()
                         .requestMatchers("/members/**").authenticated()
                         .requestMatchers("/tracks/**").authenticated()
-                        .requestMatchers("address/**").authenticated()
+                        .requestMatchers("/address/**").authenticated()
+                        .requestMatchers("images/**").authenticated()
                         .anyRequest().denyAll());
 
         http

--- a/src/main/java/com/cabin/plat/config/image/controller/ImageController.java
+++ b/src/main/java/com/cabin/plat/config/image/controller/ImageController.java
@@ -1,0 +1,25 @@
+package com.cabin.plat.config.image.controller;
+
+import com.cabin.plat.config.image.dto.ImageResponse;
+import com.cabin.plat.config.image.service.ImageService;
+import com.cabin.plat.global.common.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/images")
+@Tag(name = "이미지 API")
+public class ImageController {
+    private final ImageService imageService;
+
+    @Operation(summary = "사진 업로드", description = "사진을 업로드하여 해당 사진의 URL 을 반환합니다.")
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public BaseResponse<ImageResponse.Avatar> uploadAvatarImage(@RequestPart(value = "image") MultipartFile image) {
+        return BaseResponse.onSuccess(imageService.uploadAvatarImage(image));
+    }
+}

--- a/src/main/java/com/cabin/plat/config/image/dto/ImageResponse.java
+++ b/src/main/java/com/cabin/plat/config/image/dto/ImageResponse.java
@@ -1,0 +1,14 @@
+package com.cabin.plat.config.image.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ImageResponse {
+    @Getter
+    @Builder
+    public static class Avatar {
+        @Schema(description = "아바타 이미지 URL", example = "https://example.com/avatar.png")
+        private String avatar;
+    }
+}

--- a/src/main/java/com/cabin/plat/config/image/mapper/ImageMapper.java
+++ b/src/main/java/com/cabin/plat/config/image/mapper/ImageMapper.java
@@ -1,0 +1,13 @@
+package com.cabin.plat.config.image.mapper;
+
+import com.cabin.plat.config.image.dto.ImageResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImageMapper {
+    public ImageResponse.Avatar toAvatar(String avatar) {
+        return ImageResponse.Avatar.builder()
+                .avatar(avatar)
+                .build();
+    }
+}

--- a/src/main/java/com/cabin/plat/config/image/service/ImageService.java
+++ b/src/main/java/com/cabin/plat/config/image/service/ImageService.java
@@ -1,0 +1,8 @@
+package com.cabin.plat.config.image.service;
+
+import com.cabin.plat.config.image.dto.ImageResponse;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageService {
+    ImageResponse.Avatar uploadAvatarImage(MultipartFile image);
+}

--- a/src/main/java/com/cabin/plat/config/image/service/ImageServiceImpl.java
+++ b/src/main/java/com/cabin/plat/config/image/service/ImageServiceImpl.java
@@ -1,0 +1,20 @@
+package com.cabin.plat.config.image.service;
+
+import com.cabin.plat.config.image.dto.ImageResponse;
+import com.cabin.plat.config.image.mapper.ImageMapper;
+import com.cabin.plat.global.util.S3FileComponent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+    private final ImageMapper imageMapper;
+    private final S3FileComponent s3FileComponent;
+
+    @Override
+    public ImageResponse.Avatar uploadAvatarImage(MultipartFile image) {
+        return imageMapper.toAvatar(s3FileComponent.uploadFile("image", image));
+    }
+}

--- a/src/main/java/com/cabin/plat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/cabin/plat/domain/member/controller/MemberController.java
@@ -18,7 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/members")
-@Tag(name = "멤버 API", description = "회원 관련 API입니다. 사용자 프로필 조회, 업데이트 및 삭제, 이미지 업로드 기능을 제공합니다.")
+@Tag(name = "멤버 API", description = "회원 관련 API입니다. 사용자 프로필 조회, 업데이트 및 삭제 기능을 제공합니다.")
 public class MemberController {
     private final MemberService memberService;
 
@@ -52,12 +52,6 @@ public class MemberController {
             @AuthMember Member member,
             @RequestParam StreamType streamType) {
         return BaseResponse.onSuccess(memberService.updateStreamType(member, streamType));
-    }
-
-    @Operation(summary = "유저 프로필 사진 업로드", description = "프로필 사진을 업로드하고 URL을 반환합니다. 이미지를 `image` 파라미터로 전송하여 프로필 사진을 변경하세요. \"유저 프로필 사진 변경\" API를 호출하기 직전에 사용해서 이미지의 URL을 받으세요.")
-    @PostMapping(value = "/profile/avatar/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public BaseResponse<MemberResponse.Avatar> uploadAvatarImage(@RequestPart(value = "image") MultipartFile image) {
-        return BaseResponse.onSuccess(memberService.uploadAvatarImage(image));
     }
 
     @Operation(summary = "유저 프로필 사진 변경", description = "업로드한 이미지의 URL로 프로필 사진을 변경합니다. \"유저 프로필 사진 업로드\" API 에서 받은 이미지 URL을 `avatar` 객체에 담아 요청 본문으로 전달하세요.")

--- a/src/main/java/com/cabin/plat/domain/member/controller/MemberController.java
+++ b/src/main/java/com/cabin/plat/domain/member/controller/MemberController.java
@@ -54,7 +54,7 @@ public class MemberController {
         return BaseResponse.onSuccess(memberService.updateStreamType(member, streamType));
     }
 
-    @Operation(summary = "유저 프로필 사진 변경", description = "업로드한 이미지의 URL로 프로필 사진을 변경합니다. \"유저 프로필 사진 업로드\" API 에서 받은 이미지 URL을 `avatar` 객체에 담아 요청 본문으로 전달하세요.")
+    @Operation(summary = "유저 프로필 사진 변경", description = "업로드한 이미지의 URL로 프로필 사진을 변경합니다. \"사진 업로드\" API 에서 받은 이미지 URL을 `avatar` 객체에 담아 요청 본문으로 전달하세요.")
     @PatchMapping("/profile/avatar")
     public BaseResponse<MemberResponse.MemberId> updateAvatarUrl(@AuthMember Member member,
                                                   @RequestBody MemberRequest.Avatar avatar) {

--- a/src/main/java/com/cabin/plat/domain/member/dto/MemberResponse.java
+++ b/src/main/java/com/cabin/plat/domain/member/dto/MemberResponse.java
@@ -38,13 +38,6 @@ public class MemberResponse {
 
     @Getter
     @Builder
-    public static class Avatar {
-        @Schema(description = "아바타 이미지 URL", example = "https://example.com/avatar.png")
-        private String avatar;
-    }
-
-    @Getter
-    @Builder
     @AllArgsConstructor
     @NoArgsConstructor
     public static class MemberSignIn {

--- a/src/main/java/com/cabin/plat/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/cabin/plat/domain/member/mapper/MemberMapper.java
@@ -46,10 +46,4 @@ public class MemberMapper {
                 .email("")
                 .build();
     }
-
-    public MemberResponse.Avatar toAvatar(String avatar) {
-        return MemberResponse.Avatar.builder()
-                .avatar(avatar)
-                .build();
-    }
 }

--- a/src/main/java/com/cabin/plat/domain/member/service/MemberService.java
+++ b/src/main/java/com/cabin/plat/domain/member/service/MemberService.java
@@ -15,8 +15,6 @@ public interface MemberService {
 
     MemberResponse.MemberId updateStreamType(Member member, StreamType streamType);
 
-    MemberResponse.Avatar uploadAvatarImage(MultipartFile image);
-
     MemberResponse.MemberId updateAvatarUrl(Member member, String avatar);
 
     MemberResponse.MemberSignIn appleSocialSignIn(MemberRequest.MemberAppleSocialSignIn request, SocialType socialType);

--- a/src/main/java/com/cabin/plat/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/cabin/plat/domain/member/service/MemberServiceImpl.java
@@ -16,11 +16,9 @@ import com.cabin.plat.domain.member.entity.RefreshToken;
 import com.cabin.plat.domain.member.entity.SocialType;
 import com.cabin.plat.domain.member.mapper.AuthenticationMapper;
 import com.cabin.plat.domain.member.repository.RefreshTokenRepository;
-import com.cabin.plat.global.util.S3FileComponent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 
@@ -32,7 +30,6 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
-    private final S3FileComponent s3FileComponent;
     private final AuthenticationMapper authenticationMapper;
     private final RefreshTokenRepository refreshTokenRepository;
     private final MemberMapper memberMapper;
@@ -108,11 +105,6 @@ public class MemberServiceImpl implements MemberService {
         updateMember.setStreamType(streamType);
         memberRepository.save(updateMember);
         return memberMapper.toMemberId(updateMember.getId());
-    }
-
-    @Override
-    public Avatar uploadAvatarImage(MultipartFile image) {
-        return memberMapper.toAvatar(s3FileComponent.uploadFile("image", image));
     }
 
     @Override


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
refactor/#54/imageUpload -> develop

### 변경 사항
이미지 업로드 엔드포인트 변경

이미지 업로드가 여러 군데에서 쓰이는데 현재 uri는 `/members/avatar` 이다.
-> `/images`로 변경

### 테스트 결과
<img width="902" alt="image" src="https://github.com/user-attachments/assets/347c74b8-6c28-447a-b38c-408e5e8496a9">

