### PR TITLE
[FEAT] 멤버 탈퇴 처리

### DIFF
--- a/src/main/java/com/cabin/plat/domain/member/entity/Member.java
+++ b/src/main/java/com/cabin/plat/domain/member/entity/Member.java
@@ -1,14 +1,21 @@
 package com.cabin.plat.domain.member.entity;
 
 import com.cabin.plat.global.common.BaseEntity;
-import jakarta.persistence.*;
-import java.time.LocalDateTime;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import java.util.Objects;
-import lombok.*;
-import org.hibernate.annotations.SQLDelete;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @Builder
@@ -56,8 +63,12 @@ public class Member extends BaseEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Member)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Member)) {
+            return false;
+        }
         Member member = (Member) o;
         return id.equals(member.id) && clientId.equals(member.clientId);
     }

--- a/src/main/java/com/cabin/plat/domain/member/service/MemberService.java
+++ b/src/main/java/com/cabin/plat/domain/member/service/MemberService.java
@@ -24,4 +24,6 @@ public interface MemberService {
     MemberResponse.MemberId resign(Member member);
 
     MemberResponse.MemberId updateNickname(Member member, String nickname);
+
+    Member findMemberById(Long id);
 }

--- a/src/main/java/com/cabin/plat/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/cabin/plat/domain/member/service/MemberServiceImpl.java
@@ -1,26 +1,32 @@
 package com.cabin.plat.domain.member.service;
 
-import com.cabin.plat.domain.member.dto.MemberResponse;
-import com.cabin.plat.domain.member.dto.MemberResponse.*;
-import com.cabin.plat.domain.member.entity.Member;
-import com.cabin.plat.domain.member.entity.StreamType;
-import com.cabin.plat.domain.member.mapper.MemberMapper;
-import com.cabin.plat.domain.member.repository.MemberRepository;
-import com.cabin.plat.global.exception.RestApiException;
-import com.cabin.plat.global.exception.errorCode.MemberErrorCode;
 import com.cabin.plat.config.jwt.dto.TokenInfo;
 import com.cabin.plat.config.jwt.service.JwtUtil;
 import com.cabin.plat.domain.member.dto.MemberRequest;
+import com.cabin.plat.domain.member.dto.MemberResponse;
+import com.cabin.plat.domain.member.dto.MemberResponse.MemberId;
+import com.cabin.plat.domain.member.dto.MemberResponse.ProfileInfo;
+import com.cabin.plat.domain.member.dto.MemberResponse.ProfileStreamType;
+import com.cabin.plat.domain.member.entity.Member;
 import com.cabin.plat.domain.member.entity.PermissionRole;
 import com.cabin.plat.domain.member.entity.RefreshToken;
 import com.cabin.plat.domain.member.entity.SocialType;
+import com.cabin.plat.domain.member.entity.StreamType;
 import com.cabin.plat.domain.member.mapper.AuthenticationMapper;
+import com.cabin.plat.domain.member.mapper.MemberMapper;
+import com.cabin.plat.domain.member.repository.MemberRepository;
 import com.cabin.plat.domain.member.repository.RefreshTokenRepository;
+import com.cabin.plat.domain.playlist.entity.PlaylistTrack;
+import com.cabin.plat.domain.playlist.repository.PlaylistRepository;
+import com.cabin.plat.domain.playlist.repository.PlaylistTrackRepository;
+import com.cabin.plat.domain.track.entity.Track;
+import com.cabin.plat.domain.track.repository.TrackRepository;
+import com.cabin.plat.global.exception.RestApiException;
+import com.cabin.plat.global.exception.errorCode.MemberErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 
 @Service
@@ -33,6 +39,9 @@ public class MemberServiceImpl implements MemberService {
     private final AuthenticationMapper authenticationMapper;
     private final RefreshTokenRepository refreshTokenRepository;
     private final MemberMapper memberMapper;
+    private final TrackRepository trackRepository;
+    private final PlaylistTrackRepository playlistTrackRepository;
+    private final PlaylistRepository playlistRepository;
 
     @Override
     public MemberResponse.MemberSignIn appleSocialSignIn(
@@ -75,9 +84,9 @@ public class MemberServiceImpl implements MemberService {
             if (jwtUtil.isExpired(refreshToken)) {
                 return generateNewToken(member, isServiced);
             }
-            String newAccessToken = jwtUtil.createAccessToken(member.getId(), member.getClientId(), member.getPermissionRole());
+            String newAccessToken = jwtUtil.createAccessToken(member.getId(), member.getClientId(),
+                    member.getPermissionRole());
             TokenInfo tokenInfo = authenticationMapper.toTokenInfo(newAccessToken, refreshToken);
-
 
             refreshTokenRepository.save(new RefreshToken(member.getId(), refreshToken, newAccessToken));
             return memberMapper.toMemberSignIn(member, tokenInfo, isServiced);
@@ -85,7 +94,6 @@ public class MemberServiceImpl implements MemberService {
 
         TokenInfo tokenInfo = authenticationMapper.toTokenInfo(accessToken, refreshToken);
         return memberMapper.toMemberSignIn(member, tokenInfo, isServiced);
-
     }
 
     @Override
@@ -135,7 +143,8 @@ public class MemberServiceImpl implements MemberService {
 
         MemberResponse.MemberTokens memberTokens = jwtUtil.refreshTokens(memberId, clientId, permissionRole);
 
-        TokenInfo tokenInfo = authenticationMapper.toTokenInfo(memberTokens.getAccessToken(), memberTokens.getRefreshToken());
+        TokenInfo tokenInfo = authenticationMapper.toTokenInfo(memberTokens.getAccessToken(),
+                memberTokens.getRefreshToken());
 
         return memberMapper.toMemberSignIn(member, tokenInfo, isServiced);
     }
@@ -144,6 +153,11 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public MemberResponse.MemberId resign(Member member) {
         Member deleteMember = findMemberById(member.getId());
+        playlistRepository.findAllByMember(deleteMember).forEach(playlist -> {
+            playlistTrackRepository.findAllByPlaylistIs(playlist).forEach(PlaylistTrack::delete);
+            playlist.delete();
+        });
+        trackRepository.findAllByMember(deleteMember).forEach(Track::delete);
         deleteMember.delete();
         memberRepository.save(deleteMember);
         return memberMapper.toMemberId(deleteMember.getId());

--- a/src/main/java/com/cabin/plat/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/cabin/plat/domain/member/service/MemberServiceImpl.java
@@ -116,7 +116,8 @@ public class MemberServiceImpl implements MemberService {
         return memberMapper.toMemberId(updateMember.getId());
     }
 
-    private Member findMemberById(Long id) {
+    @Override
+    public Member findMemberById(Long id) {
         return memberRepository.findById(id).orElseThrow(() -> new RestApiException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 

--- a/src/main/java/com/cabin/plat/domain/playlist/mapper/PlaylistMapper.java
+++ b/src/main/java/com/cabin/plat/domain/playlist/mapper/PlaylistMapper.java
@@ -1,6 +1,5 @@
 package com.cabin.plat.domain.playlist.mapper;
 
-import com.cabin.plat.domain.member.dto.MemberResponse;
 import com.cabin.plat.domain.member.entity.Member;
 import com.cabin.plat.domain.playlist.dto.PlaylistRequest.PlaylistUpload;
 import com.cabin.plat.domain.playlist.dto.PlaylistResponse;
@@ -52,7 +51,8 @@ public class PlaylistMapper {
                 .build();
     }
 
-    public PlaylistResponse.Playlists.PlaylistInfo toPlaylistInfo(Playlist playlist, List<PlaylistTrack> playlistTracks) {
+    public PlaylistResponse.Playlists.PlaylistInfo toPlaylistInfo(Playlist playlist,
+                                                                  List<PlaylistTrack> playlistTracks) {
         return PlaylistInfo.builder()
                 .playlistId(playlist.getId())
                 .title(playlist.getTitle())
@@ -60,19 +60,26 @@ public class PlaylistMapper {
                 .createdAt(playlist.getCreatedAt())
                 .uploaderNicknames(playlistTracks.stream()
                         .map(PlaylistTrack::getTrack)
-                        .map(track -> track.getMember().getNickname())
+                        .map(track -> {
+                            if (track.getMember() == null) {
+                                return "알수없음";
+                            }
+                            return track.getMember().getNickname();
+                        })
                         .collect(Collectors.toUnmodifiableSet()))
                 .build();
     }
 
-    public PlaylistResponse.TrackDetailOrder toTrackDetailOrder(PlaylistTrack playlistTrack, TrackResponse.TrackDetail trackDetail) {
+    public PlaylistResponse.TrackDetailOrder toTrackDetailOrder(PlaylistTrack playlistTrack,
+                                                                TrackResponse.TrackDetail trackDetail) {
         return PlaylistResponse.TrackDetailOrder.builder()
                 .orderIndex(playlistTrack.getOrderIndex())
                 .trackDetail(trackDetail)
                 .build();
     }
 
-    public PlaylistResponse.PlaylistDetail toPlaylistDetail(Playlist playlist, List<TrackDetailOrder> trackDetailOrders) {
+    public PlaylistResponse.PlaylistDetail toPlaylistDetail(Playlist playlist,
+                                                            List<TrackDetailOrder> trackDetailOrders) {
         return PlaylistResponse.PlaylistDetail.builder()
                 .playlistId(playlist.getId())
                 .title(playlist.getTitle())

--- a/src/main/java/com/cabin/plat/domain/playlist/repository/PlaylistRepository.java
+++ b/src/main/java/com/cabin/plat/domain/playlist/repository/PlaylistRepository.java
@@ -9,5 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PlaylistRepository extends JpaRepository<Playlist, Long> {
     Page<Playlist> findAllByMember(Member member, Pageable pageable);
+    List<Playlist> findAllByMember(Member member);
     Page<Playlist> findAllByMemberAndTitleContainingIgnoreCase(Member member, String title, Pageable pageable);
 }

--- a/src/main/java/com/cabin/plat/domain/track/dto/TrackResponse.java
+++ b/src/main/java/com/cabin/plat/domain/track/dto/TrackResponse.java
@@ -3,9 +3,13 @@ package com.cabin.plat.domain.track.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-    public class TrackResponse {
+public class TrackResponse {
 
     @Getter
     @Builder

--- a/src/main/java/com/cabin/plat/domain/track/entity/Location.java
+++ b/src/main/java/com/cabin/plat/domain/track/entity/Location.java
@@ -1,8 +1,17 @@
 package com.cabin.plat.domain.track.entity;
 
 import com.cabin.plat.global.common.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 
 @Getter
@@ -10,6 +19,7 @@ import lombok.*;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@SQLRestriction("deleted_at is null")
 public class Location extends BaseEntity {
 
     @Id

--- a/src/main/java/com/cabin/plat/domain/track/entity/Track.java
+++ b/src/main/java/com/cabin/plat/domain/track/entity/Track.java
@@ -2,16 +2,25 @@ package com.cabin.plat.domain.track.entity;
 
 import com.cabin.plat.domain.member.entity.Member;
 import com.cabin.plat.global.common.BaseEntity;
-import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.SQLRestriction;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@SQLRestriction("deleted_at is null")
 public class Track extends BaseEntity {
 
     @Id
@@ -20,11 +29,11 @@ public class Track extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
+    @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "location_id", nullable = false)
+    @JoinColumn(name = "location_id")
     private Location location;
 
     @Column(nullable = false)
@@ -35,4 +44,14 @@ public class Track extends BaseEntity {
 
     @Column(name = "image_url")
     private String imageUrl;
+
+    @Override
+    public void delete() {
+        super.delete();
+        this.member = null;
+        this.content = "삭제된 게시글 입니다";
+        this.imageUrl = "";
+        this.location.delete();
+        this.location = null;
+    }
 }

--- a/src/main/java/com/cabin/plat/domain/track/repository/TrackRepository.java
+++ b/src/main/java/com/cabin/plat/domain/track/repository/TrackRepository.java
@@ -1,5 +1,6 @@
 package com.cabin.plat.domain.track.repository;
 
+import com.cabin.plat.domain.member.entity.Member;
 import com.cabin.plat.domain.track.entity.Track;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
@@ -22,4 +23,5 @@ public interface TrackRepository extends JpaRepository<Track, Long> {
             @Param("minLongitude") double minLongitude,
             @Param("maxLongitude") double maxLongitude);
     Page<Track> findAll(Pageable pageable);
+    List<Track> findAllByMember(Member member);
 }

--- a/src/main/java/com/cabin/plat/domain/track/service/TrackServiceImpl.java
+++ b/src/main/java/com/cabin/plat/domain/track/service/TrackServiceImpl.java
@@ -1,6 +1,7 @@
 package com.cabin.plat.domain.track.service;
 
 import com.cabin.plat.domain.member.entity.Member;
+import com.cabin.plat.domain.member.service.MemberService;
 import com.cabin.plat.domain.track.dto.TrackRequest;
 import com.cabin.plat.domain.track.dto.TrackResponse;
 import com.cabin.plat.domain.track.dto.TrackResponse.TrackDetail;

--- a/src/test/java/com/cabin/plat/domain/member/service/MemberServiceImplTest.java
+++ b/src/test/java/com/cabin/plat/domain/member/service/MemberServiceImplTest.java
@@ -1,0 +1,118 @@
+package com.cabin.plat.domain.member.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.cabin.plat.domain.member.entity.*;
+import com.cabin.plat.domain.test.service.TestService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class MemberServiceImplTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private TestService testService;
+
+    private List<Member> members;
+
+    @BeforeEach
+    void setUp() {
+        members = createTestMembers();
+        testService.addMockData(members.get(0));
+        testService.addMockData(members.get(1));
+        testService.addMockData(members.get(2));
+    }
+
+    private List<Member> createTestMembers() {
+        return List.of(
+                Member.builder()
+                        .permissionRole(PermissionRole.CLIENT)
+                        .clientId("0")
+                        .name("이름0")
+                        .email("이메일0")
+                        .nickname("닉네임0")
+                        .avatar("https://testimage1.avatar0/")
+                        .streamType(StreamType.APPLE_MUSIC)
+                        .socialType(SocialType.APPLE)
+                        .build(),
+                Member.builder()
+                        .permissionRole(PermissionRole.CLIENT)
+                        .clientId("1")
+                        .name("이름1")
+                        .email("이메일1")
+                        .nickname("닉네임1")
+                        .avatar("https://testimage1.avatar1/")
+                        .streamType(StreamType.APPLE_MUSIC)
+                        .socialType(SocialType.APPLE)
+                        .build(),
+                Member.builder()
+                        .permissionRole(PermissionRole.CLIENT)
+                        .clientId("2")
+                        .name("이름2")
+                        .email("이메일2")
+                        .nickname("닉네임2")
+                        .avatar("https://testimage1.avatar2/")
+                        .streamType(StreamType.APPLE_MUSIC)
+                        .socialType(SocialType.APPLE)
+                        .build()
+        );
+    }
+
+    @Nested
+    class ResignTest {
+
+        @Test
+        void 회원_탈퇴시_프로필_삭제() {
+            // given
+            Member member = members.get(0);
+
+            // when
+            memberService.resign(member);
+
+            // then
+            assertThat(memberService.findMemberById(member.getId())).isNull();
+        }
+
+        @Test
+        void 회원_탈퇴시_다른_API_호출_불가() {
+            // given
+            Member member = members.get(0);
+
+            // when
+            memberService.resign(member);
+
+            // then
+        }
+
+        @Test
+        void 회원_탈퇴한_멤버의_트랙_조회_안됨() {
+            // given
+            Member member = members.get(0);
+
+            // when
+            memberService.resign(member);
+
+            // then
+        }
+
+        @Test
+        void 회원_탈퇴한_멤버의_플레이리스트_조회_안됨() {
+            // given
+            Member member = members.get(0);
+
+            // when
+            memberService.resign(member);
+
+            // then
+        }
+    }
+}

--- a/src/test/java/com/cabin/plat/domain/playlist/service/PlaylistServiceImplTest.java
+++ b/src/test/java/com/cabin/plat/domain/playlist/service/PlaylistServiceImplTest.java
@@ -600,7 +600,7 @@ class PlaylistServiceImplTest {
             assertThat(newTrackDetail.getIsrc()).isEqualTo("isrc3");
             assertThat(newTrackDetail.getLikeCount()).isEqualTo(0);
             assertThat(newTrackDetail.getIsLiked()).isFalse();
-            assertThat(newTrackDetail.getContent()).isNotEqualTo("아카데미는 이 노래지");
+            assertThat(newTrackDetail.getContent()).isEqualTo("삭제된 게시글 입니다");
             assertThat(newTrackDetail.getImageUrl()).isEqualTo("");
             assertThat(newTrackDetail.getMember().getMemberNickname()).isEqualTo("알수없음");
             assertThat(newTrackDetail.getMember().getAvatar()).isEqualTo("");

--- a/src/test/java/com/cabin/plat/domain/playlist/service/PlaylistServiceImplTest.java
+++ b/src/test/java/com/cabin/plat/domain/playlist/service/PlaylistServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.cabin.plat.domain.member.entity.*;
 import com.cabin.plat.domain.member.repository.MemberRepository;
+import com.cabin.plat.domain.member.service.MemberService;
 import com.cabin.plat.domain.playlist.dto.PlaylistRequest;
 import com.cabin.plat.domain.playlist.dto.PlaylistRequest.PlaylistUpload;
 import com.cabin.plat.domain.playlist.dto.PlaylistRequest.TrackOrder;
@@ -17,6 +18,7 @@ import com.cabin.plat.domain.track.entity.Location;
 import com.cabin.plat.domain.track.entity.Track;
 import com.cabin.plat.domain.track.repository.LocationRepository;
 import com.cabin.plat.domain.track.repository.TrackRepository;
+import com.cabin.plat.domain.track.service.TrackService;
 import com.cabin.plat.global.exception.RestApiException;
 import java.util.*;
 import java.util.stream.IntStream;
@@ -31,6 +33,12 @@ class PlaylistServiceImplTest {
 
     @Autowired
     private PlaylistService playlistService;
+
+    @Autowired
+    private TrackService trackService;
+
+    @Autowired
+    private MemberService memberService;
 
     @Autowired
     private PlaylistRepository playlistRepository;
@@ -338,6 +346,44 @@ class PlaylistServiceImplTest {
             // then
             assertThat(playlists.getPlaylists()).isEmpty();
         }
+
+        @Test
+        void 회원_탈퇴한_멤버의_트랙이_포함된_플레이리스트_조회시_uploaderNickname_닉네임_알수없음으로_가져오기() {
+            // given
+            Member member0 = members.get(0);
+            Member member1 = members.get(1);
+            memberService.resign(member1); // 멤버 1이 탈퇴 해서 멤버 1이 업로드한 트랙2가 삭제 (트랙2는 멤버0이 만든 플레이리스트0에 포함)
+
+            // when
+            PlaylistResponse.Playlists playlists0 = playlistService.getPlaylists(member0, 0, 20);
+
+            // then
+            String title = playlists0.getPlaylists().get(0).getTitle();
+            String imageUrl = playlists0.getPlaylists().get(0).getPlaylistImageUrl();
+            Set<String> uploaderNicknames = playlists0.getPlaylists().get(0).getUploaderNicknames();
+            assertThat(title).isEqualTo("플레이리스트 제목0");
+            assertThat(imageUrl).isEqualTo("https://test0.com");
+            assertThat(uploaderNicknames).containsExactlyInAnyOrder("닉네임0", "알수없음");
+        }
+
+        @Test
+        void 삭제된_트랙이_포함된_플레이리스트_조회시_삭제된_트랙은_uploaderNickname_닉네임_알수없음으로_가져오기() {
+            // given
+            Member member0 = members.get(0);
+            Member member1 = members.get(1);
+            trackService.deleteTrack(member1, tracks.get(2).getId()); // 멤버 1이 업로드한 트랙2 삭제 (트랙2는 멤버0이 만든 플레이리스트0에 포함)
+
+            // when
+            PlaylistResponse.Playlists playlists0 = playlistService.getPlaylists(member0, 0, 20);
+
+            // then
+            String title = playlists0.getPlaylists().get(0).getTitle();
+            String imageUrl = playlists0.getPlaylists().get(0).getPlaylistImageUrl();
+            Set<String> uploaderNicknames = playlists0.getPlaylists().get(0).getUploaderNicknames();
+            assertThat(title).isEqualTo("플레이리스트 제목0");
+            assertThat(imageUrl).isEqualTo("https://test0.com");
+            assertThat(uploaderNicknames).containsExactlyInAnyOrder("닉네임0", "알수없음");
+        }
     }
 
     @Nested
@@ -407,6 +453,44 @@ class PlaylistServiceImplTest {
             // then
             assertThat(playlists.getPlaylists()).isEmpty();
         }
+
+        @Test
+        void 회원_탈퇴한_멤버의_트랙이_포함된_플레이리스트_조회시_uploaderNickname_닉네임_알수없음으로_가져오기() {
+            // given
+            Member member0 = members.get(0);
+            Member member1 = members.get(1);
+            memberService.resign(member1); // 멤버 1이 탈퇴 해서 멤버 1이 업로드한 트랙2가 삭제 (트랙2는 멤버0이 만든 플레이리스트0에 포함)
+
+            // when
+            PlaylistResponse.Playlists playlists0 = playlistService.getSearchedPlaylists(member0, "플레이리스트", 0, 20);
+
+            // then
+            String title = playlists0.getPlaylists().get(0).getTitle();
+            String imageUrl = playlists0.getPlaylists().get(0).getPlaylistImageUrl();
+            Set<String> uploaderNicknames = playlists0.getPlaylists().get(0).getUploaderNicknames();
+            assertThat(title).isEqualTo("플레이리스트 제목0");
+            assertThat(imageUrl).isEqualTo("https://test0.com");
+            assertThat(uploaderNicknames).containsExactlyInAnyOrder("닉네임0", "알수없음");
+        }
+
+        @Test
+        void 삭제된_트랙이_포함된_플레이리스트_조회시_삭제된_트랙은_uploaderNickname_닉네임_알수없음으로_가져오기() {
+            // given
+            Member member0 = members.get(0);
+            Member member1 = members.get(1);
+            trackService.deleteTrack(member1, tracks.get(2).getId()); // 멤버 1이 업로드한 트랙2 삭제 (트랙2는 멤버0이 만든 플레이리스트0에 포함)
+
+            // when
+            PlaylistResponse.Playlists playlists0 = playlistService.getSearchedPlaylists(member0, "플레이리스트", 0, 20);
+
+            // then
+            String title = playlists0.getPlaylists().get(0).getTitle();
+            String imageUrl = playlists0.getPlaylists().get(0).getPlaylistImageUrl();
+            Set<String> uploaderNicknames = playlists0.getPlaylists().get(0).getUploaderNicknames();
+            assertThat(title).isEqualTo("플레이리스트 제목0");
+            assertThat(imageUrl).isEqualTo("https://test0.com");
+            assertThat(uploaderNicknames).containsExactlyInAnyOrder("닉네임0", "알수없음");
+        }
     }
 
     @Nested
@@ -471,6 +555,18 @@ class PlaylistServiceImplTest {
             // then
 
             assertPlaylistTrackDetails(playlistDetail);
+        }
+
+        @Test
+        void 회원_탈퇴한_멤버의_트랙이_포함된_플레이리스트_디테일_조회시_노래정보_제외하고_삭제처리() {
+            // given
+            Member member = members.get(0);
+
+            // when
+            memberService.resign(member);
+
+            // then
+//            TrackDetail_안의_imageUrl_content_likeCount_isLiked_memberNickname_avatar_삭제처리
         }
 
         private void assertPlaylistTrackDetails(PlaylistResponse.PlaylistDetail playlistDetail) {

--- a/src/test/java/com/cabin/plat/domain/playlist/service/PlaylistServiceImplTest.java
+++ b/src/test/java/com/cabin/plat/domain/playlist/service/PlaylistServiceImplTest.java
@@ -1,8 +1,12 @@
 package com.cabin.plat.domain.playlist.service;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.cabin.plat.domain.member.entity.*;
+import com.cabin.plat.domain.member.entity.Member;
+import com.cabin.plat.domain.member.entity.PermissionRole;
+import com.cabin.plat.domain.member.entity.SocialType;
+import com.cabin.plat.domain.member.entity.StreamType;
 import com.cabin.plat.domain.member.repository.MemberRepository;
 import com.cabin.plat.domain.member.service.MemberService;
 import com.cabin.plat.domain.playlist.dto.PlaylistRequest;
@@ -21,11 +25,20 @@ import com.cabin.plat.domain.track.repository.LocationRepository;
 import com.cabin.plat.domain.track.repository.TrackRepository;
 import com.cabin.plat.domain.track.service.TrackService;
 import com.cabin.plat.global.exception.RestApiException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -73,9 +86,12 @@ class PlaylistServiceImplTest {
     private List<Member> createTestMembers() {
         List<Member> members = new ArrayList<>();
 
-        Member member1 = new Member(null, PermissionRole.CLIENT, "1", "이름1", "이메일1", "닉네임1", "https://testimage1.avatar/", StreamType.APPLE_MUSIC, SocialType.APPLE);
-        Member member2 = new Member(null, PermissionRole.CLIENT, "2", "이름2", "이메일2", "닉네임2", "https://testimage2.avatar/", StreamType.SPOTIFY, SocialType.APPLE);
-        Member member3 = new Member(null, PermissionRole.CLIENT, "3", "이름3", "이메일3", "닉네임3", "https://testimage3.avatar/", StreamType.APPLE_MUSIC, SocialType.APPLE);
+        Member member1 = new Member(null, PermissionRole.CLIENT, "1", "이름1", "이메일1", "닉네임1",
+                "https://testimage1.avatar/", StreamType.APPLE_MUSIC, SocialType.APPLE);
+        Member member2 = new Member(null, PermissionRole.CLIENT, "2", "이름2", "이메일2", "닉네임2",
+                "https://testimage2.avatar/", StreamType.SPOTIFY, SocialType.APPLE);
+        Member member3 = new Member(null, PermissionRole.CLIENT, "3", "이름3", "이메일3", "닉네임3",
+                "https://testimage3.avatar/", StreamType.APPLE_MUSIC, SocialType.APPLE);
 
         members.add(memberRepository.save(member1));
         members.add(memberRepository.save(member2));
@@ -89,7 +105,8 @@ class PlaylistServiceImplTest {
 
         Location domitory18 = new Location(null, "Dormitory 16 (DICE)", "경상북도 포항시 남구 지곡동 287", 36.017062, 129.321993);
         Location burgerKing = new Location(null, "버거킹 포항공대점", "경상북도 포항시 남구 청암로 77", 36.015733, 129.322700);
-        Location c5 = new Location(null, "Apple Developer Academy @ POSTECH(애플 디벨로퍼 아카데미)", "경상북도 포항시 남구 청암로 77", 36.014335, 129.325951);
+        Location c5 = new Location(null, "Apple Developer Academy @ POSTECH(애플 디벨로퍼 아카데미)", "경상북도 포항시 남구 청암로 77",
+                36.014335, 129.325951);
         Location liversAcademy = new Location(null, "", "경상북도 포항시 남구 효자동 222-24", 36.009002, 129.332852);
         Location young1Dae = new Location(null, "영일대 해수욕장", "경상북도 포항시 북구 두호동 1015", 36.056074, 129.378190);
         Location hwangLidanGil = new Location(null, "황리단길", "경상북도 경주시 황남동 포석로 일대", 35.837555, 129.209712);
@@ -107,11 +124,16 @@ class PlaylistServiceImplTest {
     private List<Track> createTestTracks(List<Member> members, List<Location> locations) {
         List<Track> tracks = new ArrayList<>();
         Track track0 = new Track(null, members.get(0), locations.get(0), "isrc1", "기숙사에서 한곡", "https://testimage1.com");
-        Track track1 = new Track(null, members.get(0), locations.get(1), "isrc2", "버거킹마을 공연 최애 노래", "https://testimage2.com");
-        Track track2 = new Track(null, members.get(1), locations.get(2), "isrc3", "아카데미는 이 노래지", "https://testimage3.com");
-        Track track3 = new Track(null, members.get(1), locations.get(3), "isrc4", "리버스아카데미 노래", "https://testimage4.com");
-        Track track4 = new Track(null, members.get(2), locations.get(4), "isrc5", "영일대는 이노래지", "https://testimage5.com");
-        Track track5 = new Track(null, members.get(2), locations.get(5), "isrc6", "황리단길과 어울리는", "https://testimage5.com");
+        Track track1 = new Track(null, members.get(0), locations.get(1), "isrc2", "버거킹마을 공연 최애 노래",
+                "https://testimage2.com");
+        Track track2 = new Track(null, members.get(1), locations.get(2), "isrc3", "아카데미는 이 노래지",
+                "https://testimage3.com");
+        Track track3 = new Track(null, members.get(1), locations.get(3), "isrc4", "리버스아카데미 노래",
+                "https://testimage4.com");
+        Track track4 = new Track(null, members.get(2), locations.get(4), "isrc5", "영일대는 이노래지",
+                "https://testimage5.com");
+        Track track5 = new Track(null, members.get(2), locations.get(5), "isrc6", "황리단길과 어울리는",
+                "https://testimage5.com");
 
         tracks.add(trackRepository.save(track0));
         tracks.add(trackRepository.save(track1));
@@ -131,11 +153,11 @@ class PlaylistServiceImplTest {
                                 .trackId(tracks.get(0).getId())
                                 .orderIndex(0)
                                 .build()
-                        ,TrackOrder.builder()
+                        , TrackOrder.builder()
                                 .trackId(tracks.get(1).getId())
                                 .orderIndex(1)
                                 .build()
-                        ,TrackOrder.builder()
+                        , TrackOrder.builder()
                                 .trackId(tracks.get(2).getId())
                                 .orderIndex(2)
                                 .build()
@@ -150,11 +172,11 @@ class PlaylistServiceImplTest {
                                 .trackId(tracks.get(3).getId())
                                 .orderIndex(0)
                                 .build()
-                        ,TrackOrder.builder()
+                        , TrackOrder.builder()
                                 .trackId(tracks.get(4).getId())
                                 .orderIndex(1)
                                 .build()
-                        ,TrackOrder.builder()
+                        , TrackOrder.builder()
                                 .trackId(tracks.get(5).getId())
                                 .orderIndex(2)
                                 .build()
@@ -169,23 +191,23 @@ class PlaylistServiceImplTest {
                                 .trackId(tracks.get(0).getId())
                                 .orderIndex(0)
                                 .build()
-                        ,TrackOrder.builder()
+                        , TrackOrder.builder()
                                 .trackId(tracks.get(1).getId())
                                 .orderIndex(1)
                                 .build()
-                        ,TrackOrder.builder()
+                        , TrackOrder.builder()
                                 .trackId(tracks.get(2).getId())
                                 .orderIndex(2)
                                 .build()
-                        ,TrackOrder.builder()
+                        , TrackOrder.builder()
                                 .trackId(tracks.get(3).getId())
                                 .orderIndex(3)
                                 .build()
-                        ,TrackOrder.builder()
+                        , TrackOrder.builder()
                                 .trackId(tracks.get(4).getId())
                                 .orderIndex(4)
                                 .build()
-                        ,TrackOrder.builder()
+                        , TrackOrder.builder()
                                 .trackId(tracks.get(5).getId())
                                 .orderIndex(5)
                                 .build()
@@ -271,11 +293,11 @@ class PlaylistServiceImplTest {
                                     .trackId(tracks.get(0).getId())
                                     .orderIndex(0)
                                     .build()
-                            ,TrackOrder.builder()
+                            , TrackOrder.builder()
                                     .trackId(tracks.get(1).getId())
                                     .orderIndex(1)
                                     .build()
-                            ,TrackOrder.builder()
+                            , TrackOrder.builder()
                                     .trackId(tracks.get(2).getId())
                                     .orderIndex(1)
                                     .build()
@@ -364,7 +386,7 @@ class PlaylistServiceImplTest {
             Set<String> uploaderNicknames = playlists0.getPlaylists().get(0).getUploaderNicknames();
             assertThat(title).isEqualTo("플레이리스트 제목0");
             assertThat(imageUrl).isEqualTo("https://test0.com");
-            assertThat(uploaderNicknames).containsExactlyInAnyOrder("닉네임0", "알수없음");
+            assertThat(uploaderNicknames).containsExactlyInAnyOrder(member0.getNickname(), "알수없음");
         }
 
         @Test
@@ -383,7 +405,24 @@ class PlaylistServiceImplTest {
             Set<String> uploaderNicknames = playlists0.getPlaylists().get(0).getUploaderNicknames();
             assertThat(title).isEqualTo("플레이리스트 제목0");
             assertThat(imageUrl).isEqualTo("https://test0.com");
-            assertThat(uploaderNicknames).containsExactlyInAnyOrder("닉네임0", "알수없음");
+            assertThat(uploaderNicknames).containsExactlyInAnyOrder(member0.getNickname(), "알수없음");
+        }
+
+        @Test
+        void 회원_탈퇴시_해당_회원이_올린_플레이리스트_모두_소프트_삭제() {
+            // given
+            Member member = members.get(0);
+            List<Sort.Order> sorts = new ArrayList<>();
+            sorts.add(Sort.Order.desc("createdAt"));
+            Pageable pageable = PageRequest.of(0, 20, Sort.by(sorts));
+
+            // when
+            memberService.resign(member);
+
+            // then
+            playlistRepository.findAllByMember(member, pageable).forEach(playlist -> {
+                assertThat(playlist.getDeletedAt()).isNotNull();
+            });
         }
     }
 
@@ -471,7 +510,7 @@ class PlaylistServiceImplTest {
             Set<String> uploaderNicknames = playlists0.getPlaylists().get(0).getUploaderNicknames();
             assertThat(title).isEqualTo("플레이리스트 제목0");
             assertThat(imageUrl).isEqualTo("https://test0.com");
-            assertThat(uploaderNicknames).containsExactlyInAnyOrder("닉네임0", "알수없음");
+            assertThat(uploaderNicknames).containsExactlyInAnyOrder(member0.getNickname(), "알수없음");
         }
 
         @Test
@@ -490,7 +529,7 @@ class PlaylistServiceImplTest {
             Set<String> uploaderNicknames = playlists0.getPlaylists().get(0).getUploaderNicknames();
             assertThat(title).isEqualTo("플레이리스트 제목0");
             assertThat(imageUrl).isEqualTo("https://test0.com");
-            assertThat(uploaderNicknames).containsExactlyInAnyOrder("닉네임0", "알수없음");
+            assertThat(uploaderNicknames).containsExactlyInAnyOrder(member0.getNickname(), "알수없음");
         }
     }
 
@@ -563,26 +602,26 @@ class PlaylistServiceImplTest {
             Member member0 = members.get(0);
             Member member1 = members.get(1);
             Long playlist0Id = playlistIds.get(0);
-            TrackDetail trackDetail = playlistService.getPlaylistDetail(member0, playlist0Id).getTracks().get(2).getTrackDetail(); // 탈퇴한 멤버가 업로드한 트랙
-            assertThat(trackDetail.getIsrc()).isEqualTo("isrc3");
-            assertThat(trackDetail.getContent()).isEqualTo("아카데미는 이 노래지");
-            assertThat(trackDetail.getImageUrl()).isEqualTo("https://testimage3.com");
-            assertThat(trackDetail.getMember().getMemberNickname()).isEqualTo("닉네임2");
-            assertThat(trackDetail.getMember().getAvatar()).isEqualTo("https://testimage3.avatar/");
-
             memberService.resign(member1);
 
             // when
-            TrackDetail newTrackDetail = playlistService.getPlaylistDetail(member0, playlist0Id).getTracks().get(2).getTrackDetail(); // 탈퇴한 멤버가 업로드한 트랙
+            TrackDetail trackDetail = playlistService.getPlaylistDetail(member0, playlist0Id).getTracks().get(2)
+                    .getTrackDetail(); // 탈퇴한 멤버가 업로드한 트랙
 
             // then
-            assertThat(newTrackDetail.getIsrc()).isEqualTo("isrc3");
-            assertThat(newTrackDetail.getLikeCount()).isEqualTo(0);
-            assertThat(newTrackDetail.getIsLiked()).isFalse();
-            assertThat(newTrackDetail.getContent()).isNotEqualTo("아카데미는 이 노래지");
-            assertThat(newTrackDetail.getImageUrl()).isEqualTo("");
-            assertThat(newTrackDetail.getMember().getMemberNickname()).isEqualTo("알수없음");
-            assertThat(newTrackDetail.getMember().getAvatar()).isEqualTo("");
+            assertThat(trackDetail.getTrackId()).isNotNull();
+            assertThat(trackDetail.getIsrc()).isNotBlank();
+            assertThat(trackDetail.getCreatedAt()).isNotNull();
+            assertThat(trackDetail.getLatitude()).isZero();
+            assertThat(trackDetail.getLongitude()).isZero();
+            assertThat(trackDetail.getBuildingName()).isBlank();
+            assertThat(trackDetail.getAddress()).isBlank();
+            assertThat(trackDetail.getImageUrl()).isEqualTo("");
+            assertThat(trackDetail.getContent()).isEqualTo("삭제된 게시글 입니다");
+            assertThat(trackDetail.getLikeCount()).isZero();
+            assertThat(trackDetail.getIsLiked()).isFalse();
+            assertThat(trackDetail.getMember().getMemberNickname()).isEqualTo("알수없음");
+            assertThat(trackDetail.getMember().getAvatar()).isEqualTo("");
         }
 
         @Test
@@ -594,7 +633,8 @@ class PlaylistServiceImplTest {
 
             // when
             trackService.deleteTrack(member1, tracks.get(2).getId());
-            TrackDetail newTrackDetail = playlistService.getPlaylistDetail(member0, playlist0Id).getTracks().get(2).getTrackDetail(); // 탈퇴한 멤버가 업로드한 트랙
+            TrackDetail newTrackDetail = playlistService.getPlaylistDetail(member0, playlist0Id).getTracks().get(2)
+                    .getTrackDetail(); // 탈퇴한 멤버가 업로드한 트랙
 
             // then
             assertThat(newTrackDetail.getIsrc()).isEqualTo("isrc3");
@@ -859,7 +899,8 @@ class PlaylistServiceImplTest {
             Long deleteTrackId = tracks.get(1).getId();
 
             // when
-            PlaylistResponse.PlayListId responsePlaylistId = playlistService.deleteTrackFromPlaylist(member, playlistId, deleteTrackId);
+            PlaylistResponse.PlayListId responsePlaylistId = playlistService.deleteTrackFromPlaylist(member, playlistId,
+                    deleteTrackId);
 
             // then
             assertThat(responsePlaylistId.getPlaylistId()).isEqualTo(playlistId);
@@ -879,7 +920,8 @@ class PlaylistServiceImplTest {
             Long deleteTrackId = tracks.get(1).getId();
 
             // when
-            PlaylistResponse.PlayListId responsePlaylistId = playlistService.deleteTrackFromPlaylist(member, playlistId, deleteTrackId);
+            PlaylistResponse.PlayListId responsePlaylistId = playlistService.deleteTrackFromPlaylist(member, playlistId,
+                    deleteTrackId);
 
             // then
             Optional<Playlist> optionalPlaylist = playlistRepository.findById(playlistId);

--- a/src/test/java/com/cabin/plat/domain/playlist/service/PlaylistServiceImplTest.java
+++ b/src/test/java/com/cabin/plat/domain/playlist/service/PlaylistServiceImplTest.java
@@ -201,7 +201,7 @@ class PlaylistServiceImplTest {
     }
 
     @Nested
-    class AddPlaylist {
+    class AddPlaylistTests {
 
         @Test
         void 플레이리스트_테이블_생성_테스트() {
@@ -341,7 +341,7 @@ class PlaylistServiceImplTest {
     }
 
     @Nested
-    class GetSearchedPlaylistsTest {
+    class GetSearchedPlaylistsTests {
 
         @Test
         void 플레이리스트_제목_검색_2개_중에_하나만_검색_성공() {
@@ -489,77 +489,50 @@ class PlaylistServiceImplTest {
 
     @Nested
     class UpdatePlaylistTests {
-//        private PlaylistRequest.PlaylistUpload newPlaylistUpload = PlaylistUpload.builder()
-//                .title("플레이리스트 제목2")
-//                .playlistImageUrl("https://test2.com")
-//                .tracks(List.of(
-//                        TrackOrder.builder()
-//                                .trackId(tracks.get(4).getId())
-//                                .orderIndex(0)
-//                                .build()
-//                        ,TrackOrder.builder()
-//                                .trackId(tracks.get(5).getId())
-//                                .orderIndex(1)
-//                                .build()
-//                ))
-//                .build();
-//
-//        @Test
-//        void 플레이리스트_수정_성공() {
-//            // given
-//            Member member = members.get(0);
-//            Long playlistId = playlistIds.get(0);
-//
-//            // when
-//            playlistService.updatePlaylistTitleAndImage(member, playlistId, newPlaylistUpload);
-//            Optional<Playlist> optionalPlaylist = playlistRepository.findById(playlistId);
-//
-//            // then
-//            assertThat(optionalPlaylist.isPresent()).isTrue();
-//            Playlist playlist = optionalPlaylist.get();
-//
-//            // 변경된 정보
-//            assertThat(playlist.getTitle()).isEqualTo("플레이리스트 제목2");
-//            assertThat(playlist.getPlaylistImageUrl()).isEqualTo("https://test2.com");
-//            assertThat(playlist.getPlaylistTracks().get(0).getId()).isEqualTo(tracks.get(4).getId());
-//            assertThat(playlist.getPlaylistTracks().get(0).getOrderIndex()).isEqualTo(0);
-//            assertThat(playlist.getPlaylistTracks().get(1).getId()).isEqualTo(tracks.get(5).getId());
-//            assertThat(playlist.getPlaylistTracks().get(1).getOrderIndex()).isEqualTo(1);
-//        }
-//
-//        @Test
-//        void 플레이리스트_수정_실패_권한없음() {
-//            // given
-//            Member member = members.get(2);
-//            Long playlistId = playlistIds.get(0);
-//
-//            // when
-//            playlistService.updatePlaylistTitleAndImage(member, playlistId, newPlaylistUpload);
-//            Optional<Playlist> optionalPlaylist = playlistRepository.findById(playlistId);
-//
-//            // then
-//            assertThat(optionalPlaylist.isPresent()).isTrue();
-//            Playlist playlist = optionalPlaylist.get();
-//
-//            // 변경안된 정보
-//            assertThat(playlist.getTitle()).isEqualTo("플레이리스트 제목0");
-//            assertThat(playlist.getPlaylistImageUrl()).isEqualTo("https://test0.com");
-//            assertThat(playlist.getPlaylistTracks().get(0).getId()).isEqualTo(tracks.get(0).getId());
-//            assertThat(playlist.getPlaylistTracks().get(0).getOrderIndex()).isEqualTo(0);
-//            assertThat(playlist.getPlaylistTracks().get(1).getId()).isEqualTo(tracks.get(1).getId());
-//            assertThat(playlist.getPlaylistTracks().get(1).getOrderIndex()).isEqualTo(1);
-//        }
-//
-//        @Test
-//        void 플레이리스트_수정_실패_권한없음_예외발생() {
-//            // given
-//            Member member = members.get(2);
-//            Long playlistId = playlistIds.get(0);
-//
-//            // when then
-//            assertThatThrownBy(() -> playlistService.updatePlaylistTitleAndImage(member, playlistId, newPlaylistUpload))
-//                    .isInstanceOf(RestApiException.class);
-//        }
+
+        private PlaylistRequest.PlaylistEdit playlistEdit = PlaylistRequest.PlaylistEdit.builder()
+                .title("플레이리스트 제목2")
+                .playlistImageUrl("https://test2.com")
+                .build();
+
+        @Test
+        void 플레이리스트_수정_성공() {
+            // given
+            Member member = members.get(0);
+            Long playlistId = playlistIds.get(0);
+
+            // when
+            playlistService.updatePlaylistTitleAndImage(member, playlistId, playlistEdit);
+            Optional<Playlist> optionalPlaylist = playlistRepository.findById(playlistId);
+
+            // then
+            assertThat(optionalPlaylist.isPresent()).isTrue();
+            Playlist playlist = optionalPlaylist.get();
+
+            // 변경된 정보
+            assertThat(playlist.getTitle()).isEqualTo("플레이리스트 제목2");
+            assertThat(playlist.getPlaylistImageUrl()).isEqualTo("https://test2.com");
+        }
+
+        @Test
+        void 플레이리스트_수정_실패_권한없음_예외발생() {
+            // given
+            Member member = members.get(2);
+            Long playlistId = playlistIds.get(0);
+
+            // when then
+            assertThatThrownBy(() -> playlistService.updatePlaylistTitleAndImage(member, playlistId, playlistEdit))
+                    .isInstanceOf(RestApiException.class);
+
+            Optional<Playlist> optionalPlaylist = playlistRepository.findById(playlistId);
+
+            // then
+            assertThat(optionalPlaylist.isPresent()).isTrue();
+            Playlist playlist = optionalPlaylist.get();
+
+            assertThat(playlist.getTitle()).isEqualTo("플레이리스트 제목0");
+            assertThat(playlist.getPlaylistImageUrl()).isEqualTo("https://test0.com");
+        }
     }
 
     @Nested

--- a/src/test/java/com/cabin/plat/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/cabin/plat/domain/track/service/TrackServiceTest.java
@@ -1,16 +1,23 @@
 package com.cabin.plat.domain.track.service;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.cabin.plat.domain.member.entity.*;
+import com.cabin.plat.domain.member.entity.Member;
+import com.cabin.plat.domain.member.entity.PermissionRole;
+import com.cabin.plat.domain.member.entity.SocialType;
+import com.cabin.plat.domain.member.entity.StreamType;
 import com.cabin.plat.domain.member.repository.MemberRepository;
+import com.cabin.plat.domain.member.service.MemberService;
 import com.cabin.plat.domain.track.dto.TrackRequest;
 import com.cabin.plat.domain.track.dto.TrackResponse;
 import com.cabin.plat.domain.track.dto.TrackResponse.TrackDetail;
+import com.cabin.plat.domain.track.dto.TrackResponse.TrackMap;
 import com.cabin.plat.domain.track.entity.Location;
 import com.cabin.plat.domain.track.entity.Track;
 import com.cabin.plat.domain.track.entity.TrackReport;
 import com.cabin.plat.domain.track.repository.LocationRepository;
+import com.cabin.plat.domain.track.repository.TrackLikeRepository;
 import com.cabin.plat.domain.track.repository.TrackReportRepository;
 import com.cabin.plat.domain.track.repository.TrackRepository;
 import com.cabin.plat.global.exception.RestApiException;
@@ -32,6 +39,9 @@ class TrackServiceTest {
     private TrackService trackService;
 
     @Autowired
+    private MemberService memberService;
+
+    @Autowired
     private TrackRepository trackRepository;
 
     @Autowired
@@ -42,6 +52,9 @@ class TrackServiceTest {
 
     @Autowired
     private TrackReportRepository trackReportRepository;
+
+    @Autowired
+    private TrackLikeRepository trackLikeRepository;
 
     private List<Member> members;
     private List<Location> locations;
@@ -59,9 +72,12 @@ class TrackServiceTest {
     private List<Member> createTestMembers() {
         List<Member> members = new ArrayList<>();
 
-        Member member1 = new Member(null, PermissionRole.CLIENT, "1", "이름1", "이메일1", "닉네임1", "https://testimage1.avatar/", StreamType.APPLE_MUSIC, SocialType.APPLE);
-        Member member2 = new Member(null, PermissionRole.CLIENT, "2", "이름2", "이메일2", "닉네임2", "https://testimage2.avatar/", StreamType.SPOTIFY, SocialType.APPLE);
-        Member member3 = new Member(null, PermissionRole.CLIENT, "3", "이름3", "이메일3", "닉네임3", "https://testimage3.avatar/", StreamType.APPLE_MUSIC, SocialType.APPLE);
+        Member member1 = new Member(null, PermissionRole.CLIENT, "1", "이름1", "이메일1", "닉네임1",
+                "https://testimage1.avatar/", StreamType.APPLE_MUSIC, SocialType.APPLE);
+        Member member2 = new Member(null, PermissionRole.CLIENT, "2", "이름2", "이메일2", "닉네임2",
+                "https://testimage2.avatar/", StreamType.SPOTIFY, SocialType.APPLE);
+        Member member3 = new Member(null, PermissionRole.CLIENT, "3", "이름3", "이메일3", "닉네임3",
+                "https://testimage3.avatar/", StreamType.APPLE_MUSIC, SocialType.APPLE);
 
         members.add(memberRepository.save(member1));
         members.add(memberRepository.save(member2));
@@ -75,7 +91,8 @@ class TrackServiceTest {
 
         Location domitory18 = new Location(null, "Dormitory 16 (DICE)", "경상북도 포항시 남구 지곡동 287", 36.017062, 129.321993);
         Location burgerKing = new Location(null, "버거킹 포항공대점", "경상북도 포항시 남구 청암로 77", 36.015733, 129.322700);
-        Location c5 = new Location(null, "Apple Developer Academy @ POSTECH(애플 디벨로퍼 아카데미)", "경상북도 포항시 남구 청암로 77", 36.014335, 129.325951);
+        Location c5 = new Location(null, "Apple Developer Academy @ POSTECH(애플 디벨로퍼 아카데미)", "경상북도 포항시 남구 청암로 77",
+                36.014335, 129.325951);
         Location liversAcademy = new Location(null, "", "경상북도 포항시 남구 효자동 222-24", 36.009002, 129.332852);
         Location young1Dae = new Location(null, "영일대 해수욕장", "경상북도 포항시 북구 두호동 1015", 36.056074, 129.378190);
         Location hwangLidanGil = new Location(null, "황리단길", "경상북도 경주시 황남동 포석로 일대", 35.837555, 129.209712);
@@ -93,11 +110,16 @@ class TrackServiceTest {
     private List<Track> createTestTracks(List<Member> members, List<Location> locations) {
         List<Track> tracks = new ArrayList<>();
         Track track1 = new Track(null, members.get(0), locations.get(0), "isrc1", "기숙사에서 한곡", "https://testimage1.com");
-        Track track2 = new Track(null, members.get(0), locations.get(1), "isrc2", "버거킹마을 공연 최애 노래", "https://testimage2.com");
-        Track track3 = new Track(null, members.get(1), locations.get(2), "isrc3", "아카데미는 이 노래지", "https://testimage3.com");
-        Track track4 = new Track(null, members.get(1), locations.get(3), "isrc4", "리버스아카데미 노래", "https://testimage4.com");
-        Track track5 = new Track(null, members.get(2), locations.get(4), "isrc5", "영일대는 이노래지", "https://testimage5.com");
-        Track track6 = new Track(null, members.get(2), locations.get(5), "isrc6", "황리단길과 어울리는", "https://testimage5.com");
+        Track track2 = new Track(null, members.get(0), locations.get(1), "isrc2", "버거킹마을 공연 최애 노래",
+                "https://testimage2.com");
+        Track track3 = new Track(null, members.get(1), locations.get(2), "isrc3", "아카데미는 이 노래지",
+                "https://testimage3.com");
+        Track track4 = new Track(null, members.get(1), locations.get(3), "isrc4", "리버스아카데미 노래",
+                "https://testimage4.com");
+        Track track5 = new Track(null, members.get(2), locations.get(4), "isrc5", "영일대는 이노래지",
+                "https://testimage5.com");
+        Track track6 = new Track(null, members.get(2), locations.get(5), "isrc6", "황리단길과 어울리는",
+                "https://testimage5.com");
 
         tracks.add(trackRepository.save(track1));
         tracks.add(trackRepository.save(track2));
@@ -124,33 +146,62 @@ class TrackServiceTest {
         assertThat(location.getLongitude()).isEqualTo(retrievedLocation.get().getLongitude());
     }
 
-    @Test
-    void getTracksByLocationTest() {
-        // given
-        TrackResponse.TrackMap expectedTrackMap1 = TrackResponse.TrackMap.builder()
-                .isrc("isrc2")
-                .isLiked(false)
-                .longitude(129.322700)
-                .latitude(36.015733)
-                .build();
+    @Nested
+    class getTracksByLocationTests {
 
-        TrackResponse.TrackMap expectedTrackMap2 = TrackResponse.TrackMap.builder()
-                .isrc("isrc3")
-                .isLiked(false)
-                .longitude(129.325951)
-                .latitude(36.014335)
-                .build();
+        @Test
+        void 트랙맵_조회_성공() {
+            // given
+            TrackResponse.TrackMap expectedTrackMap1 = TrackResponse.TrackMap.builder()
+                    .isrc("isrc2")
+                    .isLiked(false)
+                    .longitude(129.322700)
+                    .latitude(36.015733)
+                    .build();
 
-        // when
-        TrackResponse.TrackMapList trackMapList = trackService.getTracksByLocation(members.get(0), 36.016512, 129.321285, 36.012527, 129.328229);
-        List<TrackResponse.TrackMap> trackMaps = trackMapList.getTracks();
+            TrackResponse.TrackMap expectedTrackMap2 = TrackResponse.TrackMap.builder()
+                    .isrc("isrc3")
+                    .isLiked(false)
+                    .longitude(129.325951)
+                    .latitude(36.014335)
+                    .build();
 
-        // then
-        assertThat(trackMaps.size()).isEqualTo(2);
-        assertThat(trackMaps.get(0)).usingRecursiveComparison()
-                .ignoringFields("trackId").isEqualTo(expectedTrackMap1);
-        assertThat(trackMaps.get(1)).usingRecursiveComparison()
-                .ignoringFields("trackId").isEqualTo(expectedTrackMap2);
+            // when
+            TrackResponse.TrackMapList trackMapList = trackService.getTracksByLocation(members.get(0), 36.016512,
+                    129.321285, 36.012527, 129.328229);
+            List<TrackResponse.TrackMap> trackMaps = trackMapList.getTracks();
+
+            // then
+            assertThat(trackMaps.size()).isEqualTo(2);
+            assertThat(trackMaps.get(0)).usingRecursiveComparison()
+                    .ignoringFields("trackId").isEqualTo(expectedTrackMap1);
+            assertThat(trackMaps.get(1)).usingRecursiveComparison()
+                    .ignoringFields("trackId").isEqualTo(expectedTrackMap2);
+        }
+
+        @Test
+        void 트랙맵_조회_삭제된_트랙_안가져옴() {
+            // given
+            Member member0 = members.get(0);
+            trackService.deleteTrack(member0, tracks.get(0).getId());
+            trackService.deleteTrack(member0, tracks.get(1).getId());
+
+            // when
+            TrackResponse.TrackMapList trackMapList = trackService.getTracksByLocation(
+                    members.get(0),
+                    36,
+                    129,
+                    37,
+                    130
+            );
+            List<TrackResponse.TrackMap> trackMaps = trackMapList.getTracks();
+
+            // then
+            List<Long> getTrackLists = trackMaps.stream()
+                    .map(TrackMap::getTrackId)
+                    .toList();
+            assertThat(getTrackLists).doesNotContain(tracks.get(0).getId(), tracks.get(1).getId());
+        }
     }
 
     @Nested
@@ -181,6 +232,35 @@ class TrackServiceTest {
             assertThat(trackDetail.getLikeCount()).isEqualTo(0);
             assertThat(trackDetail.getIsLiked()).isEqualTo(false);
             assertThat(trackDetail.getMember()).usingRecursiveComparison().isEqualTo(memberInfo);
+        }
+
+        @Test
+        void 회원탈퇴한_회원의_트랙정보는_노래만_남는다() {
+            // given
+            Member member0 = members.get(0);
+            Member member1 = members.get(1);
+            memberService.resign(member0);
+
+            // when
+            TrackDetail trackDetail1 = trackService.getTrackById(member1, tracks.get(0).getId());
+            TrackDetail trackDetail2 = trackService.getTrackById(member1, tracks.get(1).getId());
+
+            // then
+            for (TrackDetail trackDetail : List.of(trackDetail1, trackDetail2)) {
+                assertThat(trackDetail.getTrackId()).isNotNull();
+                assertThat(trackDetail.getIsrc()).isNotBlank();
+                assertThat(trackDetail.getCreatedAt()).isNotNull();
+                assertThat(trackDetail.getLatitude()).isZero();
+                assertThat(trackDetail.getLongitude()).isZero();
+                assertThat(trackDetail.getBuildingName()).isBlank();
+                assertThat(trackDetail.getAddress()).isBlank();
+                assertThat(trackDetail.getImageUrl()).isEqualTo("");
+                assertThat(trackDetail.getContent()).isEqualTo("삭제된 게시글 입니다");
+                assertThat(trackDetail.getLikeCount()).isZero();
+                assertThat(trackDetail.getIsLiked()).isFalse();
+                assertThat(trackDetail.getMember().getMemberNickname()).isEqualTo("알수없음");
+                assertThat(trackDetail.getMember().getAvatar()).isEqualTo("");
+            }
         }
     }
 
@@ -289,20 +369,43 @@ class TrackServiceTest {
         assertThat(trackDetails).hasSize(6);
     }
 
-    @Test
-    void getTrackFeedsTest_페이지네이션() {
-        // given
-        Member member = members.get(0);
+    @Nested
+    class getTrackFeedsTests {
 
-        // when
-        List<TrackDetail> firstPageTracks = trackService.getTrackFeeds(member, 0, 4).getTrackDetails();
-        List<TrackDetail> secondPageTracks = trackService.getTrackFeeds(member, 1, 4).getTrackDetails();
-        List<TrackDetail> thirdPageTracks = trackService.getTrackFeeds(member, 2, 4).getTrackDetails();
+        @Test
+        void getTrackFeedsTest_페이지네이션() {
+            // given
+            Member member = members.get(0);
 
-        // then
-        assertThat(firstPageTracks).hasSize(4);
-        assertThat(secondPageTracks).hasSize(2);
-        assertThat(thirdPageTracks).hasSize(0);
+            // when
+            List<TrackDetail> firstPageTracks = trackService.getTrackFeeds(member, 0, 4).getTrackDetails();
+            List<TrackDetail> secondPageTracks = trackService.getTrackFeeds(member, 1, 4).getTrackDetails();
+            List<TrackDetail> thirdPageTracks = trackService.getTrackFeeds(member, 2, 4).getTrackDetails();
+
+            // then
+            assertThat(firstPageTracks).hasSize(4);
+            assertThat(secondPageTracks).hasSize(2);
+            assertThat(thirdPageTracks).hasSize(0);
+        }
+
+        @Test
+        void 회원탈퇴한_회원의_트랙은_트랙피드에_표시되지않는다() {
+            // given
+            Member member0 = members.get(0);
+            Member member1 = members.get(1);
+            // when
+            List<TrackDetail> member0Tracks1 = trackService.getTrackFeeds(member1, 0, 20).getTrackDetails();
+
+            // then
+            assertThat(member0Tracks1).hasSize(6);
+            memberService.resign(member0);
+
+            // when
+            List<TrackDetail> member0Tracks = trackService.getTrackFeeds(member1, 0, 20).getTrackDetails();
+
+            // then
+            assertThat(member0Tracks).hasSize(4);
+        }
     }
 
     @Nested


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#58/memberResign -> develop

### 변경 사항
1. 멤버 탈퇴 시 올렸던 플레이리스트와 트랙 삭제 처리
2. 플레이리스트: 소프트 딜리트
3. 트랙과 플레이리스트 관계: 소프트 딜리트
4. 트랙: 노래 정보만 남기고 나머지 정보 삭제
5. 트랙 맵 조회 또는 트랙 피드 조회시 삭제된 트랙은 조회 불가능
6. 플레이리스트에서 트랙 정보 조회 시 노래 정보는 남음

### 테스트 결과
<img width="324" alt="스크린샷 2024-11-02 오후 8 25 52" src="https://github.com/user-attachments/assets/10d4130a-904d-4031-a03d-f16551a5e8a0">
