### PR TITLE
[FEAT] 겹치는 트랙 있으면 위치 약간 조정해서 업로드

### DIFF
--- a/src/test/java/com/cabin/plat/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/cabin/plat/domain/track/service/TrackServiceTest.java
@@ -358,6 +358,39 @@ class TrackServiceTest {
     }
 
     @Test
+    void 겹치는_트랙이_있으면_위치를_조정한다() {
+        // given
+        Member member = members.get(0);
+        TrackRequest.TrackUpload trackUpload1 = TrackRequest.TrackUpload.builder()
+                .isrc("isrc9")
+                .imageUrl("https://testimage9.com")
+                .content("테스트9")
+                .latitude(36.014188)
+                .longitude(129.325802)
+                .build();
+
+        TrackRequest.TrackUpload trackUpload2 = TrackRequest.TrackUpload.builder()
+                .isrc("test")
+                .imageUrl("https://testtest.com")
+                .content("테스트test")
+                .latitude(36.014108)
+                .longitude(129.325841)
+                .build();
+
+        // when
+        Long trackId1 = trackService.addTrack(member, trackUpload1).getTrackId();
+        Long trackId2 = trackService.addTrack(member, trackUpload2).getTrackId();
+
+        // then
+        TrackResponse.TrackDetail trackDetail1 = trackService.getTrackById(member, trackId1);
+        assertThat(trackDetail1.getLatitude()).isEqualTo(36.014188);
+        assertThat(trackDetail1.getLongitude()).isEqualTo(129.325802);
+        TrackResponse.TrackDetail trackDetail2 = trackService.getTrackById(member, trackId2);
+        assertThat(trackDetail2.getLatitude()).isNotEqualTo(36.014108);
+        assertThat(trackDetail2.getLongitude()).isNotEqualTo(129.325841);
+    }
+
+    @Test
     void getTrackFeedsTest_개수만() {
         // given
         Member member = members.get(0);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#74/trackOverlap -> develop

### 변경 사항
위치가 겹치는(100미터 이내) 트랙 있으면 위치 약간 조정해서 업로드하도록 했습니다.

### 테스트 결과
<img width="348" alt="image" src="https://github.com/user-attachments/assets/a7a8dc22-bed0-44f2-8d99-c2ae84affc57">

