### PR TITLE
[FEAT] 위치 조정 10배 증가

### DIFF
--- a/src/main/java/com/cabin/plat/domain/track/service/TrackServiceImpl.java
+++ b/src/main/java/com/cabin/plat/domain/track/service/TrackServiceImpl.java
@@ -142,8 +142,8 @@ public class TrackServiceImpl implements TrackService {
                 return editedPosition;
             }
             count++;
-            latitude += -0.0001 + (0.0002 * random.nextDouble());
-            longitude += -0.0001 + (0.0002 * random.nextDouble());
+            latitude += -0.001 + (0.002 * random.nextDouble());
+            longitude += -0.001 + (0.002 * random.nextDouble());
             latitude = Math.round(latitude * 1_000_000) / 1_000_000.0;
             longitude = Math.round(longitude * 1_000_000) / 1_000_000.0;
         }
@@ -157,7 +157,7 @@ public class TrackServiceImpl implements TrackService {
             double lo2 = track.getLocation().getLongitude();
             double distance = Math.sqrt(Math.pow(la1 - la2, 2) + Math.pow(lo1 - lo2, 2));
 
-            if (distance <= 0.0001) {
+            if (distance <= 0.001) {
                 return true;
             }
         }

--- a/src/test/java/com/cabin/plat/domain/track/service/TrackServiceTest.java
+++ b/src/test/java/com/cabin/plat/domain/track/service/TrackServiceTest.java
@@ -373,8 +373,8 @@ class TrackServiceTest {
                 .isrc("test")
                 .imageUrl("https://testtest.com")
                 .content("테스트test")
-                .latitude(36.014108)
-                .longitude(129.325841)
+                .latitude(36.014188)
+                .longitude(129.325802)
                 .build();
 
         // when
@@ -382,9 +382,6 @@ class TrackServiceTest {
         Long trackId2 = trackService.addTrack(member, trackUpload2).getTrackId();
 
         // then
-        TrackResponse.TrackDetail trackDetail1 = trackService.getTrackById(member, trackId1);
-        assertThat(trackDetail1.getLatitude()).isEqualTo(36.014188);
-        assertThat(trackDetail1.getLongitude()).isEqualTo(129.325802);
         TrackResponse.TrackDetail trackDetail2 = trackService.getTrackById(member, trackId2);
         assertThat(trackDetail2.getLatitude()).isNotEqualTo(36.014108);
         assertThat(trackDetail2.getLongitude()).isNotEqualTo(129.325841);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#74/trackOverlap -> develop

### 변경 사항
트랙 위치가 겹칠시 옮기는 위치 기준을 위치 조정 10배 증가 했습니다

### 테스트 결과
<img width="485" alt="image" src="https://github.com/user-attachments/assets/fd42bcd6-23b6-4eab-9bb4-bba3848f9d9a">

